### PR TITLE
Fix ecto.migrate complaint about incorrect string

### DIFF
--- a/priv/repo/migrations/20180704001416_create_user.exs
+++ b/priv/repo/migrations/20180704001416_create_user.exs
@@ -10,7 +10,7 @@ defmodule EspyWeb.Repo.Migrations.CreateUser do
       add :is_active, :boolean, default: true, null: false
       add :email, :string
       add :avatar, :string
-      add :level, :string, default: 'free'
+      add :level, :string, default: "free"
 
       timestamps()
     end


### PR DESCRIPTION
For some reason ecto didn't want to migrate with the single quote.

OSX 10.14.4
mix 1.8.1