### PR TITLE
Ueberauth.Strategy.Twitter.OAuth uses twitter callback url

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Register Apps and add XRPL account subscriptions + Webhook endpoint URL's. The s
   * Add env variables to your environment
     * `GITHUB_CLIENT_ID` and  `GITHUB_CLIENT_SECRET` Github Sign-in
     * `TWITTER_CONSUMER_KEY` and  `TWITTER_CONSUMER_SECRET` Twitter-Sign-in
+    * `TWITTER_REDIRECT_URI` twitter app callback url (IE: `https://webhook.xrpayments.com/auth/twitter/callback`). This callback url also needs to be set in your twitter app configuration.
   * Start Phoenix endpoint with `mix phx.server`
 
 ## Start & run with Docker Compose

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       - GITHUB_CLIENT_SECRET=XXXX
       - TWITTER_CONSUMER_KEY=XXXX
       - TWITTER_CONSUMER_SECRET=XXXX
+      - TWITTER_REDIRECT_URI=https://webhook.example.com/auth/twitter/callback
   postgres:
     image: postgres:alpine
     restart: always


### PR DESCRIPTION
Ueberauth.Strategy.Twitter.OAuth uses the environment variable for passing the callback url to twitter. This needs to match the path (/auth/twitter/callback) at the webhook server and needs to be set in the twitter app settings within the developer portal. This might help others setting up a similar webhook server.